### PR TITLE
Removed chrome.downloads.setShelfEnabled lines

### DIFF
--- a/background.js
+++ b/background.js
@@ -2,8 +2,6 @@ var cleardownloads = function(){
 	var clearfreq = 5000;
 
 	setTimeout(function() {
-		chrome.downloads.setShelfEnabled(false);
-		chrome.downloads.setShelfEnabled(true);
 		chrome.downloads.erase({state: "complete"});
 	}, clearfreq)
 };


### PR DESCRIPTION
With this change Chrome, Chromium will only close the download bar if all downloads are finished.
Without this change Chrome will close the download bar after the first download is finished, leaving the other downloads invisible.
Tested with Chromium 73.0.3683.86 on Linuxmint 19.1

Tony Fabris came up with this solution, i just made this pr.